### PR TITLE
Considering using `f_blocks` because of `f_bavail` use

### DIFF
--- a/info.c
+++ b/info.c
@@ -270,7 +270,7 @@ static void disk(void) {
 
 	if (!statvfs("/", &info)) {
 		unsigned long left  = (info.f_bavail * info.f_frsize);
-		unsigned long total = (info.f_files * info.f_frsize);
+		unsigned long total = (info.f_blocks * info.f_frsize);
 		unsigned long used  = total - left;
 		float perc  = (float)used / (float)total;
 


### PR DESCRIPTION
This should fix an issue of showing the correct disk usage